### PR TITLE
chore: bump ts-repo-utils to 10.1.0 and scope per-package fmt with --cwd .

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "rollup": "4.60.2",
     "ts-codemod-lib": "2.1.7",
     "ts-data-forge": "6.9.6",
-    "ts-repo-utils": "10.0.3",
+    "ts-repo-utils": "10.1.0",
     "ts-type-forge": "3.0.1",
     "tslib": "2.8.1",
     "tsx": "4.21.0",

--- a/packages/package-a/package.json
+++ b/packages/package-a/package.json
@@ -36,6 +36,8 @@
     "doc:preview": "vite preview --config ./configs/vite.doc.config.ts",
     "doc:watch": "typedoc --options ./configs/typedoc.config.mjs --watch",
     "fmt": "format-uncommitted --cwd .",
+    "fmt:diff": "format-diff-from origin/main --cwd .",
+    "fmt:full": "prettier --ignore-unknown --no-error-on-unmatched-pattern --write .",
     "gi": "run-s gi:src fmt",
     "gi:src": "gen-index-ts ./src --index-ext .mts --export-ext .mjs --target-ext .mts --target-ext .tsx --exclude entry-point.mts",
     "lint": "eslint .",

--- a/packages/package-a/package.json
+++ b/packages/package-a/package.json
@@ -35,7 +35,7 @@
     "doc:embed": "tsx ./scripts/cmd/embed-samples.mts",
     "doc:preview": "vite preview --config ./configs/vite.doc.config.ts",
     "doc:watch": "typedoc --options ./configs/typedoc.config.mjs --watch",
-    "fmt": "prettier --write .",
+    "fmt": "format-uncommitted --cwd .",
     "gi": "run-s gi:src fmt",
     "gi:src": "gen-index-ts ./src --index-ext .mts --export-ext .mjs --target-ext .mts --target-ext .tsx --exclude entry-point.mts",
     "lint": "eslint .",

--- a/packages/package-b/package.json
+++ b/packages/package-b/package.json
@@ -36,6 +36,8 @@
     "doc:preview": "vite preview --config ./configs/vite.doc.config.ts",
     "doc:watch": "typedoc --options ./configs/typedoc.config.mjs --watch",
     "fmt": "format-uncommitted --cwd .",
+    "fmt:diff": "format-diff-from origin/main --cwd .",
+    "fmt:full": "prettier --ignore-unknown --no-error-on-unmatched-pattern --write .",
     "gi": "run-s gi:src fmt",
     "gi:src": "gen-index-ts ./src --index-ext .mts --export-ext .mjs --target-ext .mts --target-ext .tsx --exclude entry-point.mts",
     "lint": "eslint .",

--- a/packages/package-b/package.json
+++ b/packages/package-b/package.json
@@ -35,7 +35,7 @@
     "doc:embed": "tsx ./scripts/cmd/embed-samples.mts",
     "doc:preview": "vite preview --config ./configs/vite.doc.config.ts",
     "doc:watch": "typedoc --options ./configs/typedoc.config.mjs --watch",
-    "fmt": "prettier --write .",
+    "fmt": "format-uncommitted --cwd .",
     "gi": "run-s gi:src fmt",
     "gi:src": "gen-index-ts ./src --index-ext .mts --export-ext .mjs --target-ext .mts --target-ext .tsx --exclude entry-point.mts",
     "lint": "eslint .",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,13 +82,13 @@ importers:
         version: 4.60.2
       ts-codemod-lib:
         specifier: 2.1.7
-        version: 2.1.7(dedent@1.7.2)(ts-repo-utils@10.0.3(prettier@3.8.3)(typescript@5.9.3))(typescript@5.9.3)
+        version: 2.1.7(dedent@1.7.2)(ts-repo-utils@10.1.0(prettier@3.8.3)(typescript@5.9.3))(typescript@5.9.3)
       ts-data-forge:
         specifier: 6.9.6
         version: 6.9.6(typescript@5.9.3)
       ts-repo-utils:
-        specifier: 10.0.3
-        version: 10.0.3(prettier@3.8.3)(typescript@5.9.3)
+        specifier: 10.1.0
+        version: 10.1.0(prettier@3.8.3)(typescript@5.9.3)
       ts-type-forge:
         specifier: 3.0.1
         version: 3.0.1
@@ -3445,8 +3445,8 @@ packages:
   ts-morph@28.0.0:
     resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
 
-  ts-repo-utils@10.0.3:
-    resolution: {integrity: sha512-c3LKElOz+stA1RxdjYm0j9Sqxf4o0i/MS+EAusOLlW/Kx8+jQZAKhdkMuA++0RRWkKoyCwack60JUuX3SSIAuA==}
+  ts-repo-utils@10.1.0:
+    resolution: {integrity: sha512-5u5Glat76+5NN/pal00HsdYFecKYrWsiHbCYtrcpiqSqeN8oQ4Zd0i4RvLaGBtCp7qvC8ez07fmIo0RItFWC/A==}
     engines: {node: '>=22.18.0', pnpm: '>=8.0.0'}
     hasBin: true
     peerDependencies:
@@ -7342,14 +7342,14 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-codemod-lib@2.1.7(dedent@1.7.2)(ts-repo-utils@10.0.3(prettier@3.8.3)(typescript@5.9.3))(typescript@5.9.3):
+  ts-codemod-lib@2.1.7(dedent@1.7.2)(ts-repo-utils@10.1.0(prettier@3.8.3)(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       ts-data-forge: 6.9.6(typescript@5.9.3)
       ts-morph: 28.0.0
       ts-type-forge: 3.0.1
     optionalDependencies:
       dedent: 1.7.2
-      ts-repo-utils: 10.0.3(prettier@3.8.3)(typescript@5.9.3)
+      ts-repo-utils: 10.1.0(prettier@3.8.3)(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
@@ -7377,7 +7377,7 @@ snapshots:
       '@ts-morph/common': 0.29.0
       code-block-writer: 13.0.3
 
-  ts-repo-utils@10.0.3(prettier@3.8.3)(typescript@5.9.3):
+  ts-repo-utils@10.1.0(prettier@3.8.3)(typescript@5.9.3):
     dependencies:
       '@nodelib/fs.walk': 3.0.1
       '@sindresorhus/is': 8.0.0


### PR DESCRIPTION
## Summary

- Bump \`ts-repo-utils\` from 10.0.3 → 10.1.0 (introduces \`--cwd\` option on \`format-uncommitted\`)
- Switch per-package \`fmt\` scripts in \`package-a\` and \`package-b\` from \`prettier --write .\` to \`format-uncommitted --cwd .\`

## Motivation

\`fmt\` is called as a sub-step from \`gi\` and \`codemod\` chains in each package. The previous \`prettier --write .\` re-formats every file in the package on each run, which is wasteful since only the freshly-generated/modified files actually need formatting. The new \`format-uncommitted --cwd .\` formats only files that changed (per git status) within the current package — efficient and also safe under parallel ws:* runs.

## Test plan

- [x] \`pnpm install\` → lockfile updated to ts-repo-utils 10.1.0
- [x] \`pnpm run ws:build\` succeeds, both packages build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)