### PR TITLE
chore: add GitHub Sponsors FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: noshiro-pf


### PR DESCRIPTION
## Summary

- Add `.github/FUNDING.yml` to enable the GitHub Sponsors button on the repository.
- Links to the already-configured Sponsors account: https://github.com/sponsors/noshiro-pf

## Notes

Once merged into `main`, a **Sponsor** button will appear across the repository UI (issue sidebars, repo header, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)