### PR TITLE
fix: publish to GitHub Packages with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,4 +58,6 @@ jobs:
           commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NODE_AUTH_TOKEN: ${{ secrets.CHANGESET_PAT }}
+          # GitHub Packages への publish は自リポジトリ向けなので GITHUB_TOKEN で足りる
+          # （ job に packages: write を付与済み ）。install ステップも同じトークンを使う。
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Release workflow の publish が 401 で失敗していた。

  401 Unauthorized - GET https://npm.pkg.github.com/@noshiro-pf%2fpackage-a
    - unauthenticated: User cannot be authenticated with the token provided.

このリポジトリの publish 先は npmjs ではなく GitHub Packages で、認証は
NODE_AUTH_TOKEN に渡していた CHANGESET_PAT が担っていた。この PAT が失効し、
トークンは渡っているが認証できない状態になっていた。

自リポジトリの GitHub Packages への publish は GITHUB_TOKEN で足りる。
job には既に packages: write が付いており、install ステップも同じトークンを
使っているので、publish ステップを揃える。これで長命な PAT への依存が消える。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)