### PR TITLE
chore(ci): scope the release App token to the permissions it actually needs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,9 @@ jobs:
         with:
           client-id: ${{ vars.CHANGESETS_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.CHANGESETS_RELEASE_BOT_PRIVATE_KEY }}
+          # App が持つ全権限をそのまま受け取らないよう、release に必要な範囲へ明示的に絞る。
+          permission-contents: write # version ブランチの push / タグ / GitHub Release の作成
+          permission-pull-requests: write # version PR の作成と更新
 
       - name: Create Release Pull Request or Publish
         id: changesets


### PR DESCRIPTION
`release.yml` の `create-github-app-token` は `permission-*` 入力を1つも指定しておらず、発行される installation token が App の持つ全権限をそのまま受け取っていました。release に必要な範囲へ明示的に絞ります。

現在の App 付与権限（Contents + Pull requests）と完全に一致するため、**この PR 単体では挙動が変わりません**。release 系 App を `REPO_AUTOMATION_BOT`（Issues も持つ）へ統合する際に、権限が暗黙に広がる瞬間を作らないための先行適用です。