### PR TITLE
chore(ci): use REPO_AUTOMATION_BOT for release instead of the dedicated release App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CHANGESETS_RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.CHANGESETS_RELEASE_BOT_PRIVATE_KEY }}
+          client-id: ${{ vars.REPO_AUTOMATION_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.REPO_AUTOMATION_BOT_PRIVATE_KEY }}
           # App が持つ全権限をそのまま受け取らないよう、release に必要な範囲へ明示的に絞る。
           permission-contents: write # version ブランチの push / タグ / GitHub Release の作成
           permission-pull-requests: write # version PR の作成と更新

--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ pnpm i
 
 1. Run `pnpm run repo-settings:apply` to update GitHub Repository Settings.
 2. Set Actions secrets on the GUI settings page (<https://github.com/{owner}/{repo}/settings/secrets/actions>).
-    - `CHANGESETS_RELEASE_BOT_PRIVATE_KEY`
-        - <https://github.com/settings/apps/noshiro-changesets-release-bot> -> App settings -> Generate a private key
+    - `REPO_AUTOMATION_BOT_PRIVATE_KEY`
+        - <https://github.com/settings/apps/noshiro-repo-automation-bot> -> App settings -> Generate a private key
         - Required for changeset to open pull requests.

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -59,11 +59,11 @@ Repository permissions:
 1. Go to your repository's **Settings** → **Secrets and variables** → **Actions**
 
 2. Add the following **Repository secrets**:
-    - Name: `CHANGESETS_RELEASE_BOT_PRIVATE_KEY`
+    - Name: `REPO_AUTOMATION_BOT_PRIVATE_KEY`
     - Value: The entire contents of the `.pem` file you downloaded (including `-----BEGIN RSA PRIVATE KEY-----` and `-----END RSA PRIVATE KEY-----`)
 
 3. Add the following **Repository variables**:
-    - Name: `CHANGESETS_RELEASE_BOT_CLIENT_ID`
+    - Name: `REPO_AUTOMATION_BOT_CLIENT_ID`
     - Value: Your GitHub App's ID (found on the app's settings page)
 
 ## Step 5: Verify the Setup

--- a/docs/github-packages-setup.md
+++ b/docs/github-packages-setup.md
@@ -30,13 +30,13 @@ You need a GitHub Personal Access Token with the following permissions:
 
 Add the following secrets to your repository (**Settings** → **Secrets and variables** → **Actions**):
 
-- `CHANGESETS_RELEASE_BOT_PRIVATE_KEY`: GitHub App private key (already configured)
+- `REPO_AUTOMATION_BOT_PRIVATE_KEY`: GitHub App private key (already configured)
 
 ### 3. Repository Variables
 
 Add the following variables (**Settings** → **Secrets and variables** → **Actions**):
 
-- `CHANGESETS_RELEASE_BOT_CLIENT_ID`: GitHub App Client ID (already configured)
+- `REPO_AUTOMATION_BOT_CLIENT_ID`: GitHub App Client ID (already configured)
 
 ## Publishing Process
 


### PR DESCRIPTION
release 用の専用 App（ noshiro-changesets-release-bot / noshiro-semantic-release-bot ）を廃止し、`REPO_AUTOMATION_BOT` に統合します。リポジトリに置く GitHub App の秘密鍵が **3本 → 2本** になります。

token は既に `permission-contents: write` + `permission-pull-requests: write` に絞ってあるため、`REPO_AUTOMATION_BOT` が追加で `issues: write` を持っていても **release が受け取る実効権限は変わりません**。

セットアップ手順を記載した README / docs の参照名も併せて更新しています。