### PR TITLE
ci: run Claude against a failing dependency update

### DIFF
--- a/.cspell.config.yaml
+++ b/.cspell.config.yaml
@@ -5,6 +5,7 @@ caseSensitive: false
 ignoreRandomStrings: true
 words:
   - amannn
+  - anthropics
   - noshiro
   - testw
   - tscw

--- a/.github/workflows/auto-fix-pnpm-update.yml
+++ b/.github/workflows/auto-fix-pnpm-update.yml
@@ -1,0 +1,295 @@
+name: Auto-fix pnpm update
+
+# Runs Claude against a failing dependency update.
+#
+# pnpm-update.yml opens `chore/pnpm-update-<date>` every week and auto-merges it
+# once CI passes, so the update itself needs no attention — but the follow-up
+# work does, and it is the same shape every time: a major adds a lint rule, or
+# renames an API, and the pull request sits red until someone makes the small
+# change that the update implies.
+#
+# Two different things can go wrong, and they need different handling.
+#
+#   1. **CI fails on the update branch.** The branch exists and the update is
+#      already committed on it. Claude pushes the follow-up onto the same
+#      branch, which re-runs CI and lets the existing auto-merge proceed.
+#   2. **The `Weekly pnpm update` workflow itself fails.** There may be no
+#      branch, and the cause is usually the workflow or the update scripts.
+#      Claude opens a separate pull request instead, because a change there is
+#      not something to merge unattended.
+#
+# Both arrive as `workflow_run`, which always runs the copy of this file on the
+# default branch — a pull request cannot alter what this does.
+#
+# ## This is inert until `CLAUDE_CODE_OAUTH_TOKEN` exists
+#
+# The first step looks for the secret and, when it is missing, records that in
+# the run summary and skips the rest. The workflow is therefore green and does
+# nothing at all until someone adds:
+#
+#   - the repository secret `CLAUDE_CODE_OAUTH_TOKEN`, and
+#   - `permission-actions: read` on the `REPO_AUTOMATION_BOT` App installation,
+#     which is what lets Claude read the failed run's logs.
+#
+# The OAuth token is what bills a Claude subscription; `anthropic_api_key`
+# would bill the API instead. The action also accepts workload identity
+# federation — `anthropic_federation_rule_id` with `anthropic_organization_id`,
+# which exchanges the workflow's GitHub OIDC token and so keeps no long-lived
+# secret here — but that authenticates against an Anthropic *organization*,
+# which is the API side. A subscription has no such rule to point at, so the
+# stored token is the only way to use one.
+#
+# ## Why the App token rather than `GITHUB_TOKEN`
+#
+# A push made with `GITHUB_TOKEN` does not start another workflow, so CI would
+# never re-run on the fix and the pull request would sit at its old red result.
+# The App token is the same one pnpm-update.yml pushes with, and it carries
+# `workflows: write` because the failure may well be in a workflow file.
+#
+# ## Why the attempt is capped
+#
+# Claude's fix lands on the branch, CI re-runs, and a still-failing run would
+# trigger this workflow again. The cap counts commits already made here — the
+# `fix(deps):` prefix is what marks them — and stops at two. Each weekly run
+# opens a branch under a new date, so the count starts from zero again.
+
+on:
+  workflow_run:
+    workflows:
+      - 'Weekly pnpm update'
+      - 'Type Check'
+      - 'Style Check'
+      - 'Node.js Version Compatibility'
+    types:
+      - completed
+
+# Nothing here needs write access through `GITHUB_TOKEN`: every write goes
+# through the App token generated below.
+permissions:
+  contents: read
+
+concurrency:
+  # One at a time per branch. Several CI workflows fail together on the same
+  # commit, and without this each would start its own Claude against the same
+  # tree.
+  group: auto-fix-pnpm-update-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  # Case 1: CI failed on the branch `Weekly pnpm update` created. The branch is
+  # dated (`chore/pnpm-update-20260815`), so match on the prefix.
+  fix-branch:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      startsWith(github.event.workflow_run.head_branch, 'chore/pnpm-update') &&
+      github.event.workflow_run.name != 'Weekly pnpm update'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Decide whether to run
+        id: gate
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -z "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            {
+              echo '### Skipped'
+              echo
+              echo 'The repository secret `CLAUDE_CODE_OAUTH_TOKEN` is not set, so there is nothing to run.'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo 'enabled=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'enabled=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate Token
+        id: app-token
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.REPO_AUTOMATION_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.REPO_AUTOMATION_BOT_PRIVATE_KEY }}
+          permission-contents: write # ブランチへの push
+          permission-pull-requests: write # PR へのコメント
+          permission-actions: read # 失敗した run のログの読み取り
+          permission-workflows: write # workflow ファイルに触れる修正の push
+
+      - name: Checkout the failing branch
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          # The attempt cap below counts commits, and `pnpm run fmt` compares
+          # against `origin/main`.
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Check the attempt cap
+        id: attempts
+        if: steps.gate.outputs.enabled == 'true'
+        run: |
+          set -euo pipefail
+
+          # Assigned rather than piped into `wc`, so that a failing `git log`
+          # stops the job instead of counting zero and starting over.
+          previous="$(git log --format='%s' origin/main..HEAD --grep='^fix(deps): ')"
+          count="$(printf '%s' "$previous" | grep -c . || true)"
+
+          echo "Attempts so far: ${count}"
+
+          if [ "$count" -ge 2 ]; then
+            {
+              echo '### Gave up'
+              echo
+              echo "Already tried ${count} times on this branch; leaving it for a human."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo 'proceed=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'proceed=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install pnpm
+        if: steps.gate.outputs.enabled == 'true' && steps.attempts.outputs.proceed == 'true'
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - name: Set up Node.js
+        if: steps.gate.outputs.enabled == 'true' && steps.attempts.outputs.proceed == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        if: steps.gate.outputs.enabled == 'true' && steps.attempts.outputs.proceed == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Fix the failure
+        if: steps.gate.outputs.enabled == 'true' && steps.attempts.outputs.proceed == 'true'
+        uses: anthropics/claude-code-action@e63208cb983318a44e3f945e959ef894b707dcfa # v1.0.192
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          additional_permissions: |
+            actions: read
+          claude_args: '--allowedTools Bash,Read,Edit,Write,Glob,Grep'
+          prompt: |
+            The weekly dependency update opened
+            `${{ github.event.workflow_run.head_branch }}`, and
+            `${{ github.event.workflow_run.name }}` failed on it:
+
+            ${{ github.event.workflow_run.html_url }}
+
+            You are on that branch, with dependencies installed. Read the
+            failing run's logs, then make the follow-up change the update needs
+            and commit it to this branch.
+
+            Follow `AGENTS.md` — it is the instructions for this repository.
+            Note that `AGENTS.md` is generated: edit `agents/local-rules.md`
+            and run `pnpm run agents:gen` rather than editing it directly.
+
+            What matters here:
+
+            - **Fix the cause, not the symptom.** A new lint rule wants a
+              setting; a renamed API wants the new name. Do not silence a check
+              to make it pass: no `eslint-disable`, no `@ts-expect-error`, no
+              loosening a rule in `eslint.config.mts`, no skipped test.
+            - **Change only what the update broke.** Leave unrelated
+              improvements alone, and do not touch `pnpm-lock.yaml` or the
+              version ranges — the update chose those deliberately.
+            - **Verify before committing.** Run the checks that failed. If the
+              failure was in the build or type-check, `pnpm run check-all` is
+              the whole set.
+            - **Commit, do not open a pull request.** One commit, subject
+              starting `fix(deps): `, pushed to this branch. The existing pull
+              request auto-merges once CI is green again. That prefix is also
+              what caps the retries, so keep it.
+            - **If you cannot fix it** — the cause is outside this repository,
+              or the fix is a judgement call about repository policy — then
+              commit nothing and say so in a comment on the pull request,
+              describing what you found. A red pull request waiting for a human
+              is a better outcome than a green one that hid the problem.
+
+  # Case 2: the `Weekly pnpm update` workflow itself failed, so there may be no
+  # branch to fix and the cause is likely the workflow or the update scripts.
+  fix-workflow:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.name == 'Weekly pnpm update'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Decide whether to run
+        id: gate
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -z "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            {
+              echo '### Skipped'
+              echo
+              echo 'The repository secret `CLAUDE_CODE_OAUTH_TOKEN` is not set, so there is nothing to run.'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo 'enabled=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'enabled=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate Token
+        id: app-token
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.REPO_AUTOMATION_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.REPO_AUTOMATION_BOT_PRIVATE_KEY }}
+          permission-contents: write # 修正ブランチの作成
+          permission-pull-requests: write # PR の作成
+          permission-actions: read # 失敗した run のログの読み取り
+          permission-workflows: write # pnpm-update.yml 自体の修正
+
+      - name: Checkout
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Diagnose and propose a fix
+        if: steps.gate.outputs.enabled == 'true'
+        uses: anthropics/claude-code-action@e63208cb983318a44e3f945e959ef894b707dcfa # v1.0.192
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          additional_permissions: |
+            actions: read
+          claude_args: '--allowedTools Bash,Read,Edit,Write,Glob,Grep'
+          prompt: |
+            The `Weekly pnpm update` workflow itself failed — not CI on the
+            branch it opens, the workflow run:
+
+            ${{ github.event.workflow_run.html_url }}
+
+            You are on `main`. Read that run's logs and work out what happened.
+            `.github/workflows/pnpm-update.yml` has a long header comment
+            explaining what each step is for and which failures it already
+            accounts for; read it before changing anything there.
+
+            Follow `AGENTS.md` — it is the instructions for this repository.
+            Note that `AGENTS.md` is generated: edit `agents/local-rules.md`
+            and run `pnpm run agents:gen` rather than editing it directly.
+
+            What matters here:
+
+            - **Open a pull request. Do not push to `main`.** This half of the
+              automation is not something to change unattended.
+            - **Say what you found even when you cannot fix it.** A missing
+              permission or an expired credential is not something you can
+              repair from here, and describing it precisely is the useful
+              outcome. Open a pull request that only records the diagnosis in
+              the description, or leave it in the run summary.
+            - **Reproduce your reasoning against the logs.** This workflow has
+              failed before in sibling repositories in ways that looked like
+              something else: a push rejected for a missing `workflows`
+              permission, and a `--force-with-lease` with no remote-tracking
+              ref to compare against. Both reported as a plain push failure.


### PR DESCRIPTION
Ports the workflow added to mono in [noshiro-pf/mono#1619](https://github.com/noshiro-pf/mono/pull/1619). Independent of #256 — either can land first.

## Why

The weekly update auto-merges on its own, but the follow-up work does not: a major that adds a lint rule or renames an API leaves the pull request red until someone makes the same shape of change by hand.

## Shape

Two jobs, because two different things fail.

1. **CI fails on the update branch.** The branch exists and the update is committed on it, so Claude pushes the follow-up onto the same branch. CI re-runs and the existing auto-merge proceeds.
2. **The `Weekly pnpm update` workflow itself fails.** There may be no branch, and the cause is usually the workflow or the update scripts, so Claude opens a separate pull request instead — that half is not something to merge unattended.

Both arrive as `workflow_run`, which always runs the copy on the default branch, so a pull request cannot alter what this does.

Pushes go through the `REPO_AUTOMATION_BOT` App token: a push made with `GITHUB_TOKEN` starts no workflow, so CI would never re-run on the fix. Retries are capped at two by counting `fix(deps):` commits on the branch; each weekly run opens a branch under a new date, so the count starts from zero again.

## Adapted from mono in three places

- This repository's `pnpm-update.yml` opens a **dated** branch (`chore/pnpm-update-<date>`) rather than a fixed one, so the job matches on the prefix with `startsWith`.
- The `workflow_run` list names this repository's own CI workflows (`Type Check`, `Style Check`, `Node.js Version Compatibility`) plus `Weekly pnpm update`.
- Both prompts note that `AGENTS.md` is generated — edit `agents/local-rules.md` and run `pnpm run agents:gen`.

## Inert until configured

The first step of each job looks for `CLAUDE_CODE_OAUTH_TOKEN` and, when it is missing, records that in the run summary and skips the rest. Until someone adds it the workflow is green and does nothing. Turning it on needs:

- the repository secret `CLAUDE_CODE_OAUTH_TOKEN`, and
- `permission-actions: read` on the `REPO_AUTOMATION_BOT` App installation, which is what lets Claude read the failed run's logs.

`anthropics` is added to `.cspell.config.yaml`, which `typescript-template` already carries.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3jCUgDfLXHP2iM83XosJr)_