### PR TITLE
feat: type-check against the strict standard library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,10 +57,39 @@ from the root and the plain form from inside a package directory.
 **Validation:**
 
 - `pnpm run cspell` — Run spell checking (root only; it covers the whole tree).
-- `pnpm run ws:type-check` — TypeScript type checking (no emit).
+- `pnpm run ws:type-check` — TypeScript type checking (no emit), against the
+  strict standard library. **See "The strict standard library" below.**
 - `pnpm run ws:lint` / `pnpm run ws:lint:fix` — Run ESLint check/fix.
 - `pnpm run check:root` — Type-check and lint the root's own `scripts/` and `configs/`, which no package covers.
 - `pnpm run check-all` — Run all checks (types, lint, tests, markdown, spellcheck).
+
+### The strict standard library
+
+`strict-ts-lib-v7.0` replaces TypeScript's built-in library declarations with
+stricter ones — `Number.isFinite` takes a `number` rather than an `unknown`,
+`Object.keys` returns the object's own keys rather than `string[]`, and so on.
+
+- **One mechanism: a name.** The root `prepare` script runs the bundle's own
+  linker, which writes one symlink per lib group into
+  `node_modules/@typescript/`. TypeScript resolves a lib replacement as an
+  ordinary package-name lookup once `libReplacement` is on. Do not add an
+  `@typescript/lib-*` entry to `paths` — that is a second route to the same
+  place, and one that goes stale silently.
+- **Type-check with it, publish without it.** `libReplacement` is on in
+  `configs/tsconfig/tsconfig.type-check.json` and back off in
+  `configs/tsconfig/tsconfig.build.json`, which extends it. A consumer does not
+  have these declarations installed, so nothing they receive may depend on
+  them.
+- **`files` ships `src`, so the source has to read the same under either
+  library.** Types reach a consumer from `src`, not from an emitted `.d.mts`.
+  A construct that only type-checks under the strict library turns red in the
+  consumer's editor. Keep such assertions in `test/`, which `files` leaves out.
+- **`libReplacement` fails silently.** TypeScript falls back to its own
+  declarations with no diagnostic if the links go missing. That is what each
+  package's `test/strict-lib-active.mts` is for: a `@ts-expect-error` that
+  stops compiling — `TS2578` — the moment the replacement stops happening. A
+  new package copied from `package-a` should keep it, along with `"./test"` in
+  its `tsconfig.json` `include`.
 
 **Formatting:**
 

--- a/configs/tsconfig/tsconfig.build.json
+++ b/configs/tsconfig/tsconfig.build.json
@@ -1,6 +1,21 @@
 {
   "extends": "./tsconfig.type-check.json",
   "compilerOptions": {
+    // Back off the strict standard library that `tsconfig.type-check.json`
+    // turns on, because this file is what a build reads and a build's output
+    // is what consumers get.
+    //
+    // Today nothing here type-checks: rollup transpiles with esbuild, which
+    // ignores this option, and no `.d.mts` is emitted at all — consumers read
+    // types out of the `src` this package ships. So the line changes nothing
+    // yet. It matters the moment declaration emit is added, which the rollup
+    // config already says is the intent: a type left to inference would then
+    // put a name like `StrictLibInternals.ToObjectKeys` into the output, and
+    // that name exists here and nowhere in a consumer's `node_modules`.
+    //
+    // Type-check with the strict library, publish against the stock one.
+    "libReplacement": false,
+
     // Emit
     "downlevelIteration": true,
     "importHelpers": true,

--- a/configs/tsconfig/tsconfig.type-check.json
+++ b/configs/tsconfig/tsconfig.type-check.json
@@ -50,6 +50,17 @@
 
     "lib": ["ESNext", "DOM"],
 
+    // Type-check against the strict standard library instead of TypeScript's
+    // own declarations. TypeScript 6 defaults this to false, so the
+    // `@typescript/lib-*` links the root `prepare` script writes do nothing
+    // without it; both are needed. The replacement is resolved by package
+    // name, not through `paths`.
+    //
+    // This is the type-check side only. `tsconfig.build.json` extends this
+    // file and turns it back off, because what a consumer installs must not
+    // depend on declarations they do not have. See the note there.
+    "libReplacement": true,
+
     // Completeness
     "skipLibCheck": true
   }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "fmt:diff": "format-diff-from origin/main",
     "fmt:full": "prettier --ignore-unknown --no-error-on-unmatched-pattern --write .",
     "md": "markdownlint-cli2",
+    "prepare": "pnpm run z:link-strict-lib",
     "repo-settings:apply": "repo-settings apply",
     "repo-settings:backup": "repo-settings backup",
     "update-actions": "pnpm update --recursive --include-github-actions \"*/*\"",
@@ -56,7 +57,8 @@
     "ws:test:cov": "pnpm run --recursive --if-present test:cov",
     "ws:tsc": "pnpm run --recursive --if-present tsc",
     "ws:type-check": "pnpm run --recursive --if-present type-check",
-    "z:eslint": "NODE_OPTIONS='--max-old-space-size=6144' TIMING=1 eslint"
+    "z:eslint": "NODE_OPTIONS='--max-old-space-size=6144' TIMING=1 eslint",
+    "z:link-strict-lib": "strict-ts-lib-v7.0-link"
   },
   "devDependencies": {
     "@changesets/cli": "3.0.0",
@@ -86,6 +88,7 @@
     "prettier-plugin-packagejson": "3.0.2",
     "rollup": "4.62.4",
     "rollup-plugin-esbuild": "6.2.1",
+    "strict-ts-lib-v7.0": "0.6.0",
     "ts-codemod-cli": "^1.0.1",
     "ts-codemod-lib": "3.0.1",
     "ts-data-forge": "14.4.0",

--- a/packages/package-a/test/strict-lib-active.mts
+++ b/packages/package-a/test/strict-lib-active.mts
@@ -1,0 +1,22 @@
+/**
+ * Asserts that the strict standard library is actually in effect here.
+ *
+ * `libReplacement` fails silently: if the `@typescript/lib-*` links the root
+ * `prepare` script writes go missing, or the bundle stops being installed,
+ * TypeScript quietly falls back to its own declarations. Nothing errors — the
+ * package just stops being type-checked against the strict library, which is
+ * the whole point of opting in.
+ *
+ * `Number.isFinite` takes a `number` in the strict library and an `unknown` in
+ * the stock one, so `@ts-expect-error` here is an assertion in the other
+ * direction: this file stops compiling the moment the replacement stops
+ * happening.
+ *
+ * `test/` is outside `files`, so this never reaches a consumer — which matters,
+ * because under their stock library the directive below would be unused and
+ * the file would fail to compile.
+ */
+
+// @ts-expect-error A string is not a `number`, which is what the strict
+// standard library narrows this parameter to.
+export const probeIsFinite: boolean = Number.isFinite('1');

--- a/packages/package-a/tsconfig.json
+++ b/packages/package-a/tsconfig.json
@@ -3,5 +3,5 @@
     "../../configs/tsconfig/tsconfig.type-check.json",
     "../../configs/tsconfig/tsconfig.vite.json"
   ],
-  "include": ["./src", "./scripts", "./configs"]
+  "include": ["./src", "./test", "./scripts", "./configs"]
 }

--- a/packages/package-b/test/strict-lib-active.mts
+++ b/packages/package-b/test/strict-lib-active.mts
@@ -1,0 +1,22 @@
+/**
+ * Asserts that the strict standard library is actually in effect here.
+ *
+ * `libReplacement` fails silently: if the `@typescript/lib-*` links the root
+ * `prepare` script writes go missing, or the bundle stops being installed,
+ * TypeScript quietly falls back to its own declarations. Nothing errors — the
+ * package just stops being type-checked against the strict library, which is
+ * the whole point of opting in.
+ *
+ * `Number.isFinite` takes a `number` in the strict library and an `unknown` in
+ * the stock one, so `@ts-expect-error` here is an assertion in the other
+ * direction: this file stops compiling the moment the replacement stops
+ * happening.
+ *
+ * `test/` is outside `files`, so this never reaches a consumer — which matters,
+ * because under their stock library the directive below would be unused and
+ * the file would fail to compile.
+ */
+
+// @ts-expect-error A string is not a `number`, which is what the strict
+// standard library narrows this parameter to.
+export const probeIsFinite: boolean = Number.isFinite('1');

--- a/packages/package-b/tsconfig.json
+++ b/packages/package-b/tsconfig.json
@@ -3,5 +3,5 @@
     "../../configs/tsconfig/tsconfig.type-check.json",
     "../../configs/tsconfig/tsconfig.vite.json"
   ],
-  "include": ["./src", "./scripts", "./configs"]
+  "include": ["./src", "./test", "./scripts", "./configs"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       rollup-plugin-esbuild:
         specifier: 6.2.1
         version: 6.2.1(esbuild@0.28.2)(rollup@4.62.4)(supports-color@7.2.0)
+      strict-ts-lib-v7.0:
+        specifier: 0.6.0
+        version: 0.6.0(typescript@6.0.3)
       ts-codemod-cli:
         specifier: ^1.0.1
         version: 1.0.1(prettier@3.9.6)(supports-color@7.2.0)(typescript@6.0.3)
@@ -3257,6 +3260,12 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  strict-ts-lib-v7.0@0.6.0:
+    resolution: {integrity: sha512-kXC1eFZEZzUxiXM8M9VOcLqmwH9yLd8DtgXjwBI00s+6NknQCugxgJ4tUuoVbbmv5R8MieGqud1fJo1Gu2j8LA==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=6.0.0 <8.0.0'
 
   string-width@8.2.1:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
@@ -7052,6 +7061,11 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  strict-ts-lib-v7.0@0.6.0(typescript@6.0.3):
+    dependencies:
+      ts-type-forge: 9.2.1
+      typescript: 6.0.3
 
   string-width@8.2.1:
     dependencies:


### PR DESCRIPTION
## 概要

`strict-ts-lib` をこのテンプレートに導入する。**機構は 1 つ — `@typescript/lib-*` の名前解決だけ**で、`paths` は使わない。

このリポジトリのコンパイラは `typescript` 6.0.3 の 1 つだけなので（`typescript-native` は入っていない）、`strict-ts-lib-v7.0@0.6.0` の peer 範囲 `>=6.0.0 <8.0.0` にそのまま収まる。root の `prepare` が同梱リンカを走らせ、`node_modules/@typescript/` に lib グループごとのシンボリックリンクを 18 本作る。`libReplacement` は TypeScript 6 では既定 `false` なので、リンクと合わせて 2 つ揃って初めて効く。

## 入るもの

- `strict-ts-lib-v7.0@0.6.0` を root の devDependency に追加
- `prepare` → `z:link-strict-lib` → `strict-ts-lib-v7.0-link`
- `configs/tsconfig/tsconfig.type-check.json` に `libReplacement: true`
- `configs/tsconfig/tsconfig.build.json` に `libReplacement: false`（下記）
- `packages/*/test/strict-lib-active.mts` — 各パッケージの probe。`tsconfig.json` の `include` に `"./test"` を追加
- `CLAUDE.md` に「The strict standard library」節

## 型チェックでは使い、配布物では使わない

`tsconfig.build.json` は `tsconfig.type-check.json` を `extends` している。**`typescript-template` と違ってこの 2 つが繋がっている**ので、共有 config に `libReplacement: true` を書くとビルド側にも降りてくる。そこで build 側で明示的に `false` に戻した。

**この 1 行は今日の出力を何も変えない**ことも確認した。ビルドは rollup + esbuild で transpile するだけで、esbuild はこのオプションを見ない。しかも `.d.mts` は 1 つも emit されておらず、消費者は `files` で配られる `src` から型を読む。実際、build 側を `true` にして再ビルドし `diff -r` を取っても差分は出なかった。

それでも入れてあるのは、rollup config 自身のコメントが「型チェックと宣言 emit は `scripts/cmd/build.mts` の `tsc` が担う」と書いており、宣言 emit が入った時点で意味を持つからである。そのとき推論に任せた型は `StrictLibInternals.ToObjectKeys` のような名前を出力に載せうるが、その名前はこのリポジトリにしか無い。

## `files` が `src` を配ることの帰結

型は emit された宣言ではなく `src` から消費者に届く。したがって **strict lib でしか成立しない書き方をソースに入れられない** — 消費者のエディタで赤が出る。probe を `test/` に置いてあるのはそのためで、`files` は `test` を含まない。素の lib の下では probe の `@ts-expect-error` が「未使用」になるので、配ってしまうと消費者側がコンパイルできなくなる。

## 確認したこと

| 確認 | 結果 |
| :-- | :-- |
| リンク | 18 本（`ls node_modules/@typescript/`） |
| `pnpm run ws:type-check` | 2 パッケージとも通る |
| `pnpm run check:root:type` | 通る |
| negative test | リンクを外すと `package-a` / `package-b` が**それぞれ probe だけ**で落ちる（`test/strict-lib-active.mts(20,1) TS2578`）。張り直すと両方とも無エラー |
| `dist` の同一性 | build 側 `libReplacement` を `true` / `false` の両方でビルドして `diff -r` — 差分なし |
| `pnpm run check-all` | 通る（exit 0、working tree もクリーン） |

negative test を 2 パッケージ個別に走らせて、**どちらも probe 1 件だけで止まる**ことを確認している。つまり `src` はどちらの lib でも同じに読める。

## 別件（このブランチでは直していません）

作業中に、型の配布経路が繋がっていないように見える箇所が 2 つありました。strict lib とは独立の既存の話なので触っていませんが、共有しておきます。

- `packages/*/package.json` の `exports` は `"types": "./dist/index.d.mts"` を指しているが、その名前のファイルはビルド後に存在しない
- ビルドが生成する `dist/types.d.mts` の中身は `export * from './entry-point.mjs';` だが、`src` にあるエントリは `index.mts` で、`entry-point` は無い

どちらも消費者から見た型解決に関わるので、必要でしたら別途対応します。


---
_Generated by [Claude Code](https://claude.ai/code/session_016JAZRNjWhx99X9V2GdCkcH)_