### PR TITLE
fix: emit the type declarations the packages claim to publish

### DIFF
--- a/.changeset/emit-type-declarations.md
+++ b/.changeset/emit-type-declarations.md
@@ -1,0 +1,14 @@
+---
+'@noshiro-pf/package-a': patch
+'@noshiro-pf/package-b': patch
+---
+
+Publish the type declarations the manifests already pointed at.
+
+`exports["."].import.types`, `types` and `module` all named files the build
+never produced: nothing emitted declarations, and the generated
+`dist/types.d.mts` re-exported an entry point that does not exist here. A
+consumer installing either package received JavaScript and no types at all.
+
+`build` now runs `tsc --emitDeclarationOnly` after rollup, and the three
+manifest fields name files that exist.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,10 +80,13 @@ stricter ones — `Number.isFinite` takes a `number` rather than an `unknown`,
   `configs/tsconfig/tsconfig.build.json`, which extends it. A consumer does not
   have these declarations installed, so nothing they receive may depend on
   them.
-- **`files` ships `src`, so the source has to read the same under either
-  library.** Types reach a consumer from `src`, not from an emitted `.d.mts`.
-  A construct that only type-checks under the strict library turns red in the
-  consumer's editor. Keep such assertions in `test/`, which `files` leaves out.
+- **`files` ships `src`, so the source still has to read the same under either
+  library.** A consumer resolves types from the emitted `dist/*.d.mts`, but
+  `declarationMap` sends "Go to Definition" into the shipped `src`, and what
+  they open there is type-checked by their editor against the stock library. A
+  construct that only compiles under the strict one turns red for them. Keep
+  such assertions in `test/`, which `files` leaves out — the probe below would
+  itself fail to compile on their side.
 - **`libReplacement` fails silently.** TypeScript falls back to its own
   declarations with no diagnostic if the links go missing. That is what each
   package's `test/strict-lib-active.mts` is for: a `@ts-expect-error` that

--- a/configs/tsconfig/tsconfig.build.json
+++ b/configs/tsconfig/tsconfig.build.json
@@ -5,21 +5,23 @@
     // turns on, because this file is what a build reads and a build's output
     // is what consumers get.
     //
-    // Today nothing here type-checks: rollup transpiles with esbuild, which
-    // ignores this option, and no `.d.mts` is emitted at all — consumers read
-    // types out of the `src` this package ships. So the line changes nothing
-    // yet. It matters the moment declaration emit is added, which the rollup
-    // config already says is the intent: a type left to inference would then
-    // put a name like `StrictLibInternals.ToObjectKeys` into the output, and
-    // that name exists here and nowhere in a consumer's `node_modules`.
+    // This is load-bearing now that `build` emits declarations through this
+    // config: a type left to inference would otherwise put a name like
+    // `StrictLibInternals.ToObjectKeys` into `dist/*.d.mts`, and that name
+    // exists here and nowhere in a consumer's `node_modules`.
     //
     // Type-check with the strict library, publish against the stock one.
     "libReplacement": false,
 
     // Emit
-    "downlevelIteration": true,
+    //
+    // `downlevelIteration` and `importsNotUsedAsValues` are not listed:
+    // TypeScript 6.0 reports both as deprecated (TS5101) and refuses to run,
+    // and they were doing nothing here anyway — the first is a no-op with
+    // `"target": "ESNext"`, and `"remove"` was already the default behavior
+    // of the second. This config is read for declaration emit only; esbuild
+    // transpiles the JavaScript and adds its own helpers inline.
     "importHelpers": true,
-    "importsNotUsedAsValues": "remove",
     "newLine": "lf",
     "noEmit": false,
     "noEmitOnError": true,

--- a/packages/package-a/package.json
+++ b/packages/package-a/package.json
@@ -12,13 +12,13 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.mts",
+        "types": "./dist/types.d.mts",
         "default": "./dist/index.mjs"
       }
     }
   },
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "module": "./dist/index.mjs",
+  "types": "./dist/types.d.mts",
   "files": [
     "src",
     "dist",

--- a/packages/package-a/scripts/cmd/build.mts
+++ b/packages/package-a/scripts/cmd/build.mts
@@ -72,9 +72,21 @@ const build = async (skipCheck: boolean): Promise<void> => {
   });
 
   await logStep({
+    startMessage: 'Generating type declarations',
+    action: () =>
+      runCmdStep(
+        `tsc -p ${path.resolve(workspaceRootPath, './configs/tsconfig.build.json')} --emitDeclarationOnly`,
+        'Type declaration generation failed',
+      ),
+    successMessage: 'Type declarations generated',
+  });
+
+  await logStep({
     startMessage: 'Generating dist/types.d.mts',
     action: async () => {
-      const content = "export * from './entry-point.mjs';\n";
+      // Re-exports the entry point's emitted declarations under a stable
+      // name, which is what `exports` and `types` in package.json point at.
+      const content = "export * from './index.mjs';\n";
 
       const typesFile = path.resolve(distDir, 'types.d.mts');
 

--- a/packages/package-b/package.json
+++ b/packages/package-b/package.json
@@ -12,13 +12,13 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.mts",
+        "types": "./dist/types.d.mts",
         "default": "./dist/index.mjs"
       }
     }
   },
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "module": "./dist/index.mjs",
+  "types": "./dist/types.d.mts",
   "files": [
     "src",
     "dist",

--- a/packages/package-b/scripts/cmd/build.mts
+++ b/packages/package-b/scripts/cmd/build.mts
@@ -72,9 +72,21 @@ const build = async (skipCheck: boolean): Promise<void> => {
   });
 
   await logStep({
+    startMessage: 'Generating type declarations',
+    action: () =>
+      runCmdStep(
+        `tsc -p ${path.resolve(workspaceRootPath, './configs/tsconfig.build.json')} --emitDeclarationOnly`,
+        'Type declaration generation failed',
+      ),
+    successMessage: 'Type declarations generated',
+  });
+
+  await logStep({
     startMessage: 'Generating dist/types.d.mts',
     action: async () => {
-      const content = "export * from './entry-point.mjs';\n";
+      // Re-exports the entry point's emitted declarations under a stable
+      // name, which is what `exports` and `types` in package.json point at.
+      const content = "export * from './index.mjs';\n";
 
       const typesFile = path.resolve(distDir, 'types.d.mts');
 


### PR DESCRIPTION
## 概要

#268 の本文で共有した「型の配布経路が繋がっていない」2 件の対応です。**結論としては、消費者はどちらのパッケージからも型を 1 つも受け取れていませんでした。**

## 何が壊れていたか

| 宣言 | 実際 |
| :-- | :-- |
| `exports["."].import.types` = `./dist/index.d.mts` | **そのファイルは生成されない** |
| `types` = `./dist/index.d.ts` | 同上（拡張子も違う） |
| `module` = `./dist/index.js` | 生成されるのは `index.mjs` |
| `dist/types.d.mts` の中身 = `export * from './entry-point.mjs';` | **`entry-point` は存在しない**。エントリは `src/index.mts` |

`build` は rollup + esbuild で **transpile しかしておらず**、宣言を emit するステップがありませんでした。`configs/tsconfig/tsconfig.build.json` には `declaration: true` / `declarationDir` が書いてあるのに、それを使って `tsc` を回す箇所がどこにも無い、という状態です。

## なぜ配線されていなかったか

**その config では `tsc` が起動できなかったからです。**

```
configs/tsconfig.build.json(6,3): error TS5101: Option 'downlevelIteration' is
deprecated and will stop functioning in TypeScript 7.0.
```

TypeScript 6.0 は `downlevelIteration` と `importsNotUsedAsValues` を deprecated として拒否します。どちらも実質無意味で、前者は `"target": "ESNext"` では no-op、後者の `"remove"` は既定動作そのものです。単一パッケージ版のテンプレートでは既に両方削除済みで、コメントも残っています。

## 直したもの

- `configs/tsconfig/tsconfig.build.json` — 上記 2 オプションを削除（理由をコメントに記載）
- `packages/*/scripts/cmd/build.mts` — rollup の後に `tsc -p ./configs/tsconfig.build.json --emitDeclarationOnly` を追加。単一パッケージ版と同じ形
- `dist/types.d.mts` の生成内容 — `export * from './index.mjs';`（実在するエントリ）
- `packages/*/package.json` — `exports…types` / `types` を `./dist/types.d.mts`、`module` を `./dist/index.mjs` へ

ビルド後の `dist/` はこうなります。

```
expect-type.d.mts   expect-type.d.mts.map   expect-type.mjs   …
index.d.mts         index.d.mts.map         index.mjs         …
types.d.mts         tsconfig.json
```

## 確認したこと

**workspace の外に消費者を作って実測しました。** `node_modules/@noshiro-pf/package-a` をパッケージへの symlink にし、`moduleResolution: NodeNext` で名前指定 import します。

```ts
import { expectType } from '@noshiro-pf/package-a';

expectType<1, 1>('=');
```

`tsc` は **エラー 0 件**で通ります（修正前は型が 1 つも解決できません）。`exports` マップ経由で `dist/types.d.mts` → `dist/index.d.mts` と辿れていることの確認です。

そのほか:

- `pnpm run ws:build` — 2 パッケージとも成功、宣言が emit されている
- `pnpm run ws:type-check` / `check:root:type` — 通る
- `pnpm run fmt` / `cspell` / `md` — 通る

ローカルの `check-all` は待たず、残りは CI に委ねています。

## ついでに直したコメント 2 箇所

宣言が emit されるようになったことで、#268 で書いた記述のうち 2 つが事実と食い違うようになったので直しました。

- `tsconfig.build.json` の `libReplacement: false` — 「今日の出力は何も変わらない、宣言 emit が入った時点で意味を持つ」と書いていました。**その時点が来た**ので、いま効いている、という記述に変更
- `CLAUDE.md` — 「型は `src` から届く」と書いていました。いまは `dist/*.d.mts` から届きます。ただし `declarationMap` により Go to Definition は同梱の `src` に飛ぶので、**ソースをどちらの lib でも同じに読める状態に保つ必要はそのまま**です（probe を `test/` に置いている理由も同じ）


---
_Generated by [Claude Code](https://claude.ai/code/session_016JAZRNjWhx99X9V2GdCkcH)_